### PR TITLE
Pin requirements-dev for CI runs

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
-black
-build
-flake8
-intake_esm
-mypy
-pytest
-pytest-cov
-twine
+black==22.10.0
+build==0.9.0
+flake8==5.0.4
+intake_esm==2022.9.18
+mypy==0.990
+pytest==7.2.0
+pytest-cov==4.0.0
+twine==4.0.1


### PR DESCRIPTION
Pin in requirements-dev and have dependabot bump, testing for individual breaks.