### PR TITLE
Remove bad .cfg "comments" from flake8 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Test coverage badge to README.
 - Daily testing in CI.
+### Changed
+- Fix bad comments in flake8 config section causing flake8 6.0.0  runs to error.
 
 ## [0.2.0] - 2022-03-25
 ### Added

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,9 +33,9 @@ testpaths = tests
 
 [flake8]
 ignore =
-    E203 # whitespace before ':'
-    E402 # module level import not at top of file
-    E501 # line too long
-    W503 # line break before binary operator
+    E203
+    E402
+    E501
+    W503
 exclude=
     .eggs


### PR DESCRIPTION
These comments aren't actually comments and cause errors when using the newly released `flake8` v6.0.0.

Without this, `flake8` throws errors in CI like:
```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.8/x64/bin/flake8", line 8, in <module>
    sys.exit(main())
  File "/opt/hostedtoolcache/Python/3.10.8/x64/lib/python3.10/site-packages/flake8/main/cli.py", line 23, in main
    app.run(argv)
  File "/opt/hostedtoolcache/Python/3.10.8/x64/lib/python3.10/site-packages/flake8/main/application.py", line 198, in run
    self._run(argv)
  File "/opt/hostedtoolcache/Python/3.10.8/x64/lib/python3.10/site-packages/flake8/main/application.py", line 186, in _run
    self.initialize(argv)
  File "/opt/hostedtoolcache/Python/3.10.8/x64/lib/python3.10/site-packages/flake8/main/application.py", line 165, in initialize
    self.plugins, self.options = parse_args(argv)
  File "/opt/hostedtoolcache/Python/3.10.8/x64/lib/python3.10/site-packages/flake8/options/parse_args.py", line 53, in parse_args
    opts = aggregator.aggregate_options(option_manager, cfg, cfg_dir, rest)
  File "/opt/hostedtoolcache/Python/3.10.8/x64/lib/python3.10/site-packages/flake8/options/aggregator.py", line 30, in aggregate_options
    parsed_config = config.parse_config(manager, cfg, cfg_dir)
  File "/opt/hostedtoolcache/Python/3.10.8/x64/lib/python3.10/site-packages/flake8/options/config.py", line [13](https://github.com/brews/dearprudence/actions/runs/3536319171/jobs/5935244851#step:7:14)1, in parse_config
    raise ValueError(
ValueError: Error code '#' supplied to 'ignore' option does not match '^[A-Z]{1,3}[0-9]{0,3}$'
Error: Process completed with exit code 1.
```
From [this job](https://github.com/brews/dearprudence/actions/runs/3536319171/jobs/5935244851).

Related to PR #9.