### PR TITLE
List optional pkg deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Test coverage badge to README.
 - Daily testing in CI.
+- List optional dependencies given in pyproject.toml.
 ### Changed
 - Remove text warning about this software being an early prototype.
 - Fix bad comments in flake8 config section causing flake8 6.0.0  runs to error.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Install with `pip` using:
 pip install dearprudence
 ```
 
-`dearprudence` requires Python > 3.9. No external packages are required. The `intake_esm` package may need to be installed to use `dearprudence.check_cmip6_catalog()`.
+`dearprudence` requires Python > 3.9. No external packages are required. The `intake_esm` package needs to be installed to use `dearprudence.check_cmip6_catalog()`.
 
 Install the unreleased bleeding-edge version of the package with:
 ```shell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,21 @@ classifiers = [
 "Homepage" = "https://github.com/brews/dearprudence"
 "Bug Tracker" = "https://github.com/brews/dearprudence/issues"
 
+[project.optional-dependencies]
+catalog = [
+    "intake_esm",
+]
+dev = [
+    "black",
+    "build",
+    "flake8",
+    "intake_esm",
+    "mypy",
+    "pytest",
+    "pytest-cov",
+    "twine",
+]
+
 [tool.hatch.version]
 source = "vcs"
 fallback-version = "999"


### PR DESCRIPTION
Lists optional dependencies in "dev" and "catalog" sections of pyproject.toml. Can install like

```
pip install dearprudence[dev]
```

or likely more commonly used

```
pip install dearprudence[catalog]
```