### PR TITLE
Check for dataclass instances before encoding as JSON, upgrade mypy to 1.11.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Check code format with `ruff` instead of `black`.
+- Check for dataclass instances before encoding as JSON, guarding against edge case.
 
 ## [1.1.0] - 2023-07-25
 ### Changed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 intake_esm==2024.2.6
-mypy==1.10.1
+mypy==1.11.0
 pytest==8.2.2
 pytest-cov==5.0.0
 ruff==0.5.3

--- a/src/dearprudence/io.py
+++ b/src/dearprudence/io.py
@@ -65,7 +65,8 @@ class _DataclassJSONEncoder(json.JSONEncoder):
     """Encoder to dump dataclasses to JSON"""
 
     def default(self, o: Any) -> Any:
-        if dataclasses.is_dataclass(o):
+        if dataclasses.is_dataclass(o) and not isinstance(o, type):
+            # if clause ensures o is DataclassInstance and not Type[DataclassInstance]
             return dataclasses.asdict(o)
         return super().default(o)
 


### PR DESCRIPTION
Fixes edge bug in how data is encoded to JSON. This was found in PR #149, when mypy got bumped to v1.11.0, so we're updating that dependency here.